### PR TITLE
[refactor] 뉴스 데이터 가져오는 양 지정 가능

### DIFF
--- a/routes/news.js
+++ b/routes/news.js
@@ -30,7 +30,7 @@ router.get('/crypto', async (req, res, next) => {
 
 router.get('/economy', async (req, res, next) => {
    try {
-      const { length } = req.params
+      const { length } = req.query
       const newsData = await naverApi.get('', { params: { query: '경제', sort: 'date', display: length } })
       res.json({
          success: true,


### PR DESCRIPTION
query값 length를 통해 1~100만큼 뉴스를 가져올수 있습니다. 쿼리값이 없으면 기본 10개의 뉴스를 가져옵니다